### PR TITLE
Parse .gcov line data based on line number ID

### DIFF
--- a/uncov-gcov
+++ b/uncov-gcov
@@ -336,14 +336,13 @@ def combine_reports(original, new):
     report = {}
     report['name'] = original['name']
     report['source_digest'] = original['source_digest']
-    assert original['coverage'].keys() == new['coverage'].keys()
-    line_numbers = original['coverage'].keys()
-    coverage = {}
-    for lnum, orig_line, new_line in zip(line_numbers, original['coverage'].values(), new['coverage'].values()):
-        coverage[lnum] = Line(0, False)
-        if orig_line.relevant or new_line.relevant:
-            coverage[lnum].relevant = True
-            coverage[lnum].count = orig_line.count + new_line.count
+    coverage = original['coverage']
+    for line_num, line in new['coverage'].items():
+        if line_num not in coverage:
+            coverage[line_num] = line
+        else:
+            if line.relevant:
+                coverage[line_num] += line.count
 
     report['coverage'] = coverage
     return report

--- a/uncov-gcov
+++ b/uncov-gcov
@@ -343,7 +343,8 @@ def combine_reports(original, new):
             coverage[line_num] = line
         else:
             if line.relevant:
-                coverage[line_num] += line.count
+                coverage[line_num].relevant = True
+                coverage[line_num].count += line.count
 
     report['coverage'] = coverage
     return report

--- a/uncov-gcov
+++ b/uncov-gcov
@@ -55,6 +55,8 @@ def create_args(params):
                         help='print verbose messages')
     parser.add_argument('--dryrun', action='store_true',
                         help='run the script without printing report')
+    parser.add_argument('--cpp-dtor-invocations', action='store_true',
+                        help='count coverage for C++ destructor invocations')
     parser.add_argument('--gcov', metavar='FILE', default='gcov',
                         help='set the location of gcov')
     parser.add_argument('--gcov-options', metavar='GCOV_OPTS', default='',
@@ -268,7 +270,7 @@ class Line():
         self.count = count
         self.relevant = relevant
 
-def parse_gcov_file(fobj, filename):
+def parse_gcov_file(fobj, filename, args):
     """Parses the content of .gcov file"""
     coverage = {}
     ignoring = False
@@ -302,13 +304,12 @@ def parse_gcov_file(fobj, filename):
             ignoring = False
 
         # parse current line data
+        disposal = []
+        if not args.cpp_dtor_invocations:
+            disposal.extend(['}', '};'])
         if line_num not in coverage:
             coverage[line_num] = Line(0, False)
-        # XXX: provide an option to disable the second check?
-        # FIXME: [fabianw@mavt.ethz.ch; 2021-05-27] why is the second check
-        # relevant?
-        # if cov_num == '-' or text.strip() in ['}', '};']:
-        if cov_num == '-':
+        if cov_num == '-' or text.strip() in disposal:
             coverage[line_num].relevant = False
         elif cov_num in ['#####', '=====', '$$$$$', '%%%%%'] :
             # Avoid false positives.
@@ -441,7 +442,8 @@ def collect(args):
                         src_report['source_digest'] = \
                                 hashlib.md5(data).hexdigest()
 
-                    src_report['coverage'] = parse_gcov_file(fobj, gcov_path)
+                    src_report['coverage'] = \
+                            parse_gcov_file(fobj, gcov_path, args)
                     if src_path in src_files:
                         src_files[src_path] = \
                                 combine_reports(src_files[src_path], src_report)

--- a/uncov-gcov
+++ b/uncov-gcov
@@ -261,9 +261,16 @@ def run_gcov(args):
                                       path.join(root, files))
 
 
+# data type to represent a collected line
+class Line():
+    """Describes the state of a collected source line"""
+    def __init__(self, count=0, relevant=False):
+        self.count = count
+        self.relevant = relevant
+
 def parse_gcov_file(fobj, filename):
     """Parses the content of .gcov file"""
-    coverage = []
+    coverage = {}
     ignoring = False
     for line in fobj:
         report_fields = line.decode('utf-8', 'replace').split(':', 2)
@@ -293,24 +300,29 @@ def parse_gcov_file(fobj, filename):
                 sys.stderr.write("Warning: %s:%d: LCOV_EXCL_STOP is the "
                                  "correct keyword\n" % (filename, line_num))
             ignoring = False
+
+        # parse current line data
+        if line_num not in coverage:
+            coverage[line_num] = Line(0, False)
         # XXX: provide an option to disable the second check?
-        if cov_num == '-' or text.strip() in ['}', '};']:
-            coverage.append(None)
-        elif cov_num == '#####':
+        # FIXME: [fabianw@mavt.ethz.ch; 2021-05-27] why is the second check
+        # relevant?
+        # if cov_num == '-' or text.strip() in ['}', '};']:
+        if cov_num == '-':
+            coverage[line_num].relevant = False
+        elif cov_num in ['#####', '=====', '$$$$$', '%%%%%'] :
             # Avoid false positives.
             if (
                 ignoring or
                 re.search(r'\bLCOV_EXCL_LINE\b|^\s*\b(inline|static)\b', text)
             ):
-                coverage.append(None)
+                coverage[line_num].relevant = False
             else:
-                coverage.append(0)
-        elif cov_num == '=====':
-            # This is indicitive of a gcov output parse error.
-            # XXX: this is not the case, see `man gcov`.
-            coverage.append(0)
+                # no count added here since line was missed but is relevant
+                coverage[line_num].relevant = True
         else:
-            coverage.append(int(cov_num.rstrip('*')))
+            coverage[line_num].count += int(cov_num.rstrip('*'))
+            coverage[line_num].relevant = True
     return coverage
 
 
@@ -324,19 +336,14 @@ def combine_reports(original, new):
     report = {}
     report['name'] = original['name']
     report['source_digest'] = original['source_digest']
-    coverage = []
-    for original_num, new_num in zip(original['coverage'], new['coverage']):
-        if original_num is None:
-            coverage.append(new_num)
-        elif new_num is None:
-            coverage.append(original_num)
-        else:
-            coverage.append(original_num + new_num)
-
-    covered = 0
-    for c in coverage:
-        if c is not None:
-            covered = covered + c
+    assert original['coverage'].keys() == new['coverage'].keys()
+    line_numbers = original['coverage'].keys()
+    coverage = {}
+    for lnum, orig_line, new_line in zip(line_numbers, original['coverage'].values(), new['coverage'].values()):
+        coverage[lnum] = Line(0, False)
+        if orig_line.relevant or new_line.relevant:
+            coverage[lnum].relevant = True
+            coverage[lnum].count = orig_line.count + new_line.count
 
     report['coverage'] = coverage
     return report
@@ -361,10 +368,12 @@ def collect_non_report_files(args, discovered_files):
             if filepath not in discovered_files:
                 src_report = {}
                 src_report['name'] = posix_path(filepath)
-                coverage = []
+                coverage = {}
                 with io.open(abs_filepath, mode='rb') as fobj:
+                    line_num = 1
                     for _ in fobj:
-                        coverage.append(None)
+                        coverage[line_num] = Line(0, False)
+                        line_num += 1
                     fobj.seek(0)
                     data = fobj.read()
                     src_report['source_digest'] = hashlib.md5(data).hexdigest()
@@ -559,11 +568,11 @@ def run():
         print(rec['name'])
         print(rec['source_digest'])
         print(len(rec['coverage']))
-        for c in rec['coverage']:
-            if c is None:
+        for line in rec['coverage'].values():
+            if not line.relevant:
                 print(-1, end=" ")
             else:
-                print(c, end=" ")
+                print(line.count, end=" ")
         print()
 
 # TODO: consider checking that working directory is clean in a try to make sure


### PR DESCRIPTION
.gcov files may include multiple instances of a class/function if they
are templates and explicitly instantiated in a source file.  Appending
line information generates wrong metrics because a line with the same
line number may be counted as two different lines.  The counts for these
lines should be added instead.
